### PR TITLE
correct wrong url for hunspell

### DIFF
--- a/_posts/2016-06-08-hunspell.md
+++ b/_posts/2016-06-08-hunspell.md
@@ -54,5 +54,5 @@ pip install hunspell
 
 #### **Reference**
 
-* `hunspell` home page - <https://github.com/blatinier/pyhunspell>
+* `hunspell` home page - <https://hunspell.github.io/>
 * `pyhunspell` - <https://github.com/blatinier/pyhunspell>


### PR DESCRIPTION
URL of pyhunspell was given as URL of hunspell